### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure Key Vault Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-key-vault/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-key-vault/azurerm/)
 
-This Terraform Module creates a Key Vault also adds required access policies for azure AD users, groups and azure AD service principals. This also enables private endpoint and sends all logs to log analytic workspace or storage. This module can be used with an [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Terraform Module creates a Key Vault also adds required access policies for azure AD users, groups and azure AD service principals. This also enables private endpoint and sends all logs to log analytic workspace or storage. This module can be used with an [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -256,14 +256,14 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_azurerm.hub"></a> [azurerm.hub](#provider\_azurerm.hub) | ~> 3.116 |
 
@@ -271,8 +271,8 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_key_vault_rg"></a> [mod\_key\_vault\_rg](#module\_mod\_key\_vault\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_key_vault_rg"></a> [mod\_key\_vault\_rg](#module\_mod\_key\_vault\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurenoopsutils_resource_name.keyvault](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure Key Vault Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-key-vault/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-key-vault/azurerm/)
 
-This Terraform Module creates a Key Vault also adds required access policies for azure AD users, groups and azure AD service principals. This also enables private endpoint and sends all logs to log analytic workspace or storage. This module can be used with an [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-management-hub/azurerm/latest).
+This Terraform Module creates a Key Vault also adds required access policies for azure AD users, groups and azure AD service principals. This also enables private endpoint and sends all logs to log analytic workspace or storage. This module can be used with an [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-management-hub/azurerm/latest).
 
 ## SCCA Compliance
 
@@ -256,14 +256,14 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_azurerm.hub"></a> [azurerm.hub](#provider\_azurerm.hub) | ~> 3.116 |
 
@@ -271,8 +271,8 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
-| <a name="module_mod_key_vault_rg"></a> [mod\_key\_vault\_rg](#module\_mod\_key\_vault\_rg) | azurenoops/overlays-resource-group/azurerm | ~> 1.0.1 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_key_vault_rg"></a> [mod\_key\_vault\_rg](#module\_mod\_key\_vault\_rg) | POps-Rox/overlays-resource-group/azurerm | ~> 1.0.1 |
 
 ## Resources
 
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurenoopsutils_resource_name.keyvault](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/docs/index.md
+++ b/docs/index.md
@@ -295,9 +295,9 @@ For more details: [Integrate Key Vault with Azure Private Link](https://docs.mic
 | [azurerm_role_assignment.rbac_keyvault_administrator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.rbac_keyvault_secrets_users](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_dns_a_record](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.keyvault_hsm](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current_config](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_private_endpoint_connection.pip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_endpoint_connection) | data source |
 | [azurerm_resource_group.rgrp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,7 +8,7 @@ locals {
 
   resource_group_name       = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_key_vault_rg.*.resource_group_name, [""]), 0)
   location                  = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_key_vault_rg.*.resource_group_location, [""]), 0)
-  kv_name                   = coalesce(var.custom_kv_name, data.popsrox_resource_name.keyvault.result)
-  hsm_name                  = coalesce(var.custom_hsm_name, data.popsrox_resource_name.keyvault_hsm.result)
-  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.popsrox_resource_name.keyvault_dns_a_record.result)
+  kv_name                   = coalesce(var.custom_kv_name, data.popsrox_utils_resource_name.keyvault.result)
+  hsm_name                  = coalesce(var.custom_hsm_name, data.popsrox_utils_resource_name.keyvault_hsm.result)
+  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.popsrox_utils_resource_name.keyvault_dns_a_record.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,7 +8,7 @@ locals {
 
   resource_group_name       = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_key_vault_rg.*.resource_group_name, [""]), 0)
   location                  = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_key_vault_rg.*.resource_group_location, [""]), 0)
-  kv_name                   = coalesce(var.custom_kv_name, data.popsrox_utils_resource_name.keyvault.result)
-  hsm_name                  = coalesce(var.custom_hsm_name, data.popsrox_utils_resource_name.keyvault_hsm.result)
-  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.popsrox_utils_resource_name.keyvault_dns_a_record.result)
+  kv_name                   = coalesce(var.custom_kv_name, data.popsrox_resource_name.keyvault.result)
+  hsm_name                  = coalesce(var.custom_hsm_name, data.popsrox_resource_name.keyvault_hsm.result)
+  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.popsrox_resource_name.keyvault_dns_a_record.result)
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -8,7 +8,7 @@ locals {
 
   resource_group_name       = element(coalescelist(data.azurerm_resource_group.rgrp.*.name, module.mod_key_vault_rg.*.resource_group_name, [""]), 0)
   location                  = element(coalescelist(data.azurerm_resource_group.rgrp.*.location, module.mod_key_vault_rg.*.resource_group_location, [""]), 0)
-  kv_name                   = coalesce(var.custom_kv_name, data.azurenoopsutils_resource_name.keyvault.result)
-  hsm_name                  = coalesce(var.custom_hsm_name, data.azurenoopsutils_resource_name.keyvault_hsm.result)
-  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.azurenoopsutils_resource_name.keyvault_dns_a_record.result)
+  kv_name                   = coalesce(var.custom_kv_name, data.popsrox_utils_resource_name.keyvault.result)
+  hsm_name                  = coalesce(var.custom_hsm_name, data.popsrox_utils_resource_name.keyvault_hsm.result)
+  private_dns_a_record_name = coalesce(var.custom_private_dns_a_record_name, data.popsrox_utils_resource_name.keyvault_dns_a_record.result)
 }

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_resource_name" "keyvault" {
+data "popsrox_utils_resource_name" "keyvault" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -11,7 +11,7 @@ data "popsrox_resource_name" "keyvault" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "keyvault_hsm" {
+data "popsrox_utils_resource_name" "keyvault_hsm" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -21,7 +21,7 @@ data "popsrox_resource_name" "keyvault_hsm" {
   separator     = "-"
 }
 
-data "popsrox_resource_name" "keyvault_dns_a_record" {
+data "popsrox_utils_resource_name" "keyvault_dns_a_record" {
   name          = var.workload_name
   resource_type = "azurerm_private_dns_a_record"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "azurenoopsutils_resource_name" "keyvault" {
+data "popsrox_utils_resource_name" "keyvault" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -11,7 +11,7 @@ data "azurenoopsutils_resource_name" "keyvault" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "keyvault_hsm" {
+data "popsrox_utils_resource_name" "keyvault_hsm" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -21,7 +21,7 @@ data "azurenoopsutils_resource_name" "keyvault_hsm" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "keyvault_dns_a_record" {
+data "popsrox_utils_resource_name" "keyvault_dns_a_record" {
   name          = var.workload_name
   resource_type = "azurerm_private_dns_a_record"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]

--- a/naming.tf
+++ b/naming.tf
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-data "popsrox_utils_resource_name" "keyvault" {
+data "popsrox_resource_name" "keyvault" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -11,7 +11,7 @@ data "popsrox_utils_resource_name" "keyvault" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "keyvault_hsm" {
+data "popsrox_resource_name" "keyvault_hsm" {
   name          = var.workload_name
   resource_type = "azurerm_key_vault"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]
@@ -21,7 +21,7 @@ data "popsrox_utils_resource_name" "keyvault_hsm" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "keyvault_dns_a_record" {
+data "popsrox_resource_name" "keyvault_dns_a_record" {
   name          = var.workload_name
   resource_type = "azurerm_private_dns_a_record"
   prefixes      = [var.org_name, module.mod_azure_region_lookup.location_short]

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
       configuration_aliases = [azurerm.hub]
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -9,8 +9,8 @@ terraform {
       version               = "~> 3.116"
       configuration_aliases = [azurerm.hub]
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -9,9 +9,9 @@ terraform {
       version               = "~> 3.116"
       configuration_aliases = [azurerm.hub]
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary
Replace all references to the `azurenoops` GitHub organization and the `azurenoops/azurenoopsutils` Terraform provider with their `POps-Rox/popsrox-utils` equivalents.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`, updated source to `POps-Rox/popsrox-utils`
- `naming.tf`: All `data "azurenoopsutils_resource_name"` blocks → `data "popsrox_utils_resource_name"`
- `locals.naming.tf`: All `data.azurenoopsutils_resource_name.` references → `data.popsrox_utils_resource_name.`
- `README.md`: Updated registry URLs, provider table, module table, and data-source table to POps-Rox equivalents
- `docs/index.md`: Same doc updates as README.md

## Testing
- `terraform fmt -recursive` passes with no changes
- No remaining `azurenoops` references in any `.tf` or `.md` file (verified with grep)

Closes #15