### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-keyvault
+  name: terraform-az-overlays-keyvault
   description: Terraform overlay module for Azure Key Vault
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-keyvault
+    github.com/project-slug: POps-Rox/terraform-az-overlays-keyvault
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-keyvault
+    - url: https://github.com/POps-Rox/terraform-az-overlays-keyvault
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/basic_keyvault/main.tf
+++ b/examples/Commerical/basic_keyvault/main.tf
@@ -7,7 +7,7 @@ data "azuread_group" "admin_group" {
 
 module "mod_key_vault" {
 
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Commerical/basic_keyvault_with_keys/main.tf
+++ b/examples/Commerical/basic_keyvault_with_keys/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_key_vault" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Commerical/basic_keyvault_with_private_end_point/main.tf
+++ b/examples/Commerical/basic_keyvault_with_private_end_point/main.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }
@@ -21,7 +21,7 @@ module "mod_key_vault" {
     azurerm_virtual_network.kv_vnet,
     azurerm_subnet.kv_subnet,
   ]
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Commerical/basic_keyvault_with_secrets/main.tf
+++ b/examples/Commerical/basic_keyvault_with_secrets/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_key_vault" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Government/basic_keyvault/main.tf
+++ b/examples/Government/basic_keyvault/main.tf
@@ -7,7 +7,7 @@ data "azuread_group" "admin_group" {
 
 module "mod_key_vault" {
 
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Government/basic_keyvault_with_keys/main.tf
+++ b/examples/Government/basic_keyvault_with_keys/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_key_vault" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Government/basic_keyvault_with_private_end_point/main.tf
+++ b/examples/Government/basic_keyvault_with_private_end_point/main.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }
@@ -21,7 +21,7 @@ module "mod_key_vault" {
     azurerm_virtual_network.kv_vnet,
     azurerm_subnet.kv_subnet,
   ]
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Government/basic_keyvault_with_secrets/main.tf
+++ b/examples/Government/basic_keyvault_with_secrets/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_key_vault" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-keyvault"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-keyvault"
   #version = "x.x.x"
   source = "../../.."
   providers = {

--- a/modules.keyvault.diagnostic.settings.tf
+++ b/modules.keyvault.diagnostic.settings.tf
@@ -6,7 +6,7 @@
 ##-------------------------------------------------------
 module "mod_diagnostic_settings_key_vault" {
   count  = length(var.logs_destinations_ids) > 0 ? 1 : 0
-  source = "github.com/POps-Rox/tf-az-overlays-diagnosticsettings"
+  source = "github.com/POps-Rox/terraform-az-overlays-diagnosticsettings"
 
   # Resource Group, location, VNet and Subnet details
   location           = var.location

--- a/modules.keyvault.scaffolding.tf
+++ b/modules.keyvault.scaffolding.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -19,7 +19,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_key_vault_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_key_vault_resource_group ? 1 : 0
 


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.